### PR TITLE
Remove wrapping inside task info widget.

### DIFF
--- a/src/ui/task_info_widget.rs
+++ b/src/ui/task_info_widget.rs
@@ -148,10 +148,7 @@ impl WidgetTrait for TaskInfoWidget {
                 text.push(styled_line("Updated", &updated_at, None));
             }
 
-            Paragraph::new(text)
-                .block(h.block())
-                .wrap(Wrap { trim: false })
-                .render(area, buf);
+            Paragraph::new(text).block(h.block()).render(area, buf);
         } else {
             Paragraph::new("Nothing selected...")
                 .block(h.block())


### PR DESCRIPTION
Closes #92 