### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/panter-dsd/tatuin/security/code-scanning/13](https://github.com/panter-dsd/tatuin/security/code-scanning/13)

To address this issue, we must add an explicit `permissions` block to the workflow YAML. The best practice is to add this as a top-level block, which will then apply to all jobs in the workflow unless overridden for individual jobs. Given the current workflow jobs, specifying `contents: read` as the minimum is appropriate since the jobs pull repository contents and publish crates, but do not require broader write access (e.g., for issues or pull requests). This change ensures that the `GITHUB_TOKEN` is only granted the least permissions necessary, enhancing security and adhering to GitHub best practices.

Edit the workflow file `.github/workflows/publish.yaml`, inserting the following after the `name:` and before the `on:` keys:

```yaml
permissions:
  contents: read
```

This change can be made at the root level of the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
