### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crate_type.yaml
+++ b/.github/workflows/crate_type.yaml
@@ -1,4 +1,6 @@
 name: Crate Type
+permissions:
+  contents: read
 on:
   workflow_call:
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/panter-dsd/tatuin/security/code-scanning/11](https://github.com/panter-dsd/tatuin/security/code-scanning/11)

To fix the problem, we should explicitly add a `permissions` block to the workflow or the affected job with the minimum needed permissions. Since none of the steps appear to require write permission to contents, issues, or pull-requests, the minimal `contents: read` permission is appropriate. 

The standard and simplest approach is to add the following under the workflow's name (`name: Crate Type`):  
```yaml
permissions:
  contents: read
```
This will apply the minimal permission to the whole workflow. Alternatively, we could place it under the job (e.g., under `check-crate-type:`), but the root is suitable here.

No new methods, imports, or extra steps are needed—just the addition of the `permissions` YAML block at the correct location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
