### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cargo_semver_checks.yaml
+++ b/.github/workflows/cargo_semver_checks.yaml
@@ -1,4 +1,6 @@
 name: Cargo Semver Checks
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/panter-dsd/tatuin/security/code-scanning/8](https://github.com/panter-dsd/tatuin/security/code-scanning/8)

To follow the principle of least privilege, you should specify a `permissions:` block at the workflow or job level. Since none of the jobs require more than read access (all actions shown just fetch/checkout code, install tools, and run local commands), setting the minimum required permissions globally makes sense. The best location is immediately after the `name:` and before `on:` at the top, or immediately after `on:` but before `jobs:`. The minimal required permission for most CI jobs that only need to fetch code is `contents: read`. This fixes the warning and ensures the GITHUB_TOKEN has only the privileges needed.

Edit `.github/workflows/cargo_semver_checks.yaml`:

- Add the following after the `name:` block:
  ```yaml
  permissions:
    contents: read
  ```

No further changes, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
