### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_msrv.yaml
+++ b/.github/workflows/check_msrv.yaml
@@ -1,4 +1,6 @@
 name: Check MSRV
+permissions:
+  contents: read
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/panter-dsd/tatuin/security/code-scanning/5](https://github.com/panter-dsd/tatuin/security/code-scanning/5)

The best way to fix this issue is to add a `permissions` block limiting the workflow’s permissions to the least necessary. Since the steps only check out code and run Rust tooling (and do not write to the repository, create issues, manage PRs, etc.), this workflow likely only needs `contents: read`.  
Add the following at the top-level of the workflow file (e.g., after `name:`) so that all jobs inherit these restricted permissions.  
No other changes, imports, or code edits are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
