### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cargo_miri.yaml
+++ b/.github/workflows/cargo_miri.yaml
@@ -1,4 +1,6 @@
 name: Cargo Miri
+permissions:
+  contents: read
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/panter-dsd/tatuin/security/code-scanning/4](https://github.com/panter-dsd/tatuin/security/code-scanning/4)

To address the problem, you should explicitly declare a `permissions` block restricting the GITHUB_TOKEN to the minimum needed. In this case, since the workflow only needs to check out code (requires read access to contents), you can add `permissions: { contents: read }` at the top level of the workflow (applied to all jobs), directly after the `name:` or `on:` block.

Specifically, in `.github/workflows/cargo_miri.yaml`, add:
```yaml
permissions:
  contents: read
```
after the `name: Cargo Miri` line and before the `on:` block, or just after the `on:` block (before `jobs:`). This ensures the job runs with only content read permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
