### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cargo_deny.yaml
+++ b/.github/workflows/cargo_deny.yaml
@@ -1,6 +1,8 @@
 # Check for licenses and advisores
 # ../../deny.toml
 name: Cargo deny
+permissions:
+  contents: read
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/panter-dsd/tatuin/security/code-scanning/3](https://github.com/panter-dsd/tatuin/security/code-scanning/3)

To fix this issue, you should add a `permissions` block to the workflow at either the root level or inside each job. Since none of the jobs require write access and only perform read operations on repository contents, it's best to set the lowest required permissions. The recommended setting is `contents: read`, which allows jobs to read repository content but not write. This can be set at the workflow root, making it effective for all jobs, unless overridden. The change should be made by adding the following block after the workflow name definition, and before the `on` block for clarity (though placement just after the `name` or right before `jobs` is fine as long as it's within the workflow YAML).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
